### PR TITLE
Add bundle generation to blueprint and scripts to generate widget ftl…

### DIFF
--- a/generators/entity-server/index.js
+++ b/generators/entity-server/index.js
@@ -3,23 +3,28 @@
 const chalk = require('chalk');
 const casual = require('casual');
 const EntityServerGenerator = require('generator-jhipster/generators/entity-server');
+const EntandoNeedle = require('./needle-api/needle-server-bundle');
+const fs = require('fs');
 const serverFiles = require('./files').serverFiles;
 const microFrontEndFiles = require('./files').microFrontEndFiles;
 
 module.exports = class extends EntityServerGenerator {
+
+
     constructor(args, opts) {
         super(args, Object.assign({ fromBlueprint: true }, opts)); // fromBlueprint variable is important
 
-        const jhContext = (this.jhipsterContext = this.options.jhipsterContext);
+        this.jhContext = (this.jhipsterContext = this.options.jhipsterContext);
 
-        if (!jhContext) {
+        if (!this.jhContext) {
             this.error(`This is a JHipster blueprint and should be used only like ${chalk.yellow('jhipster --blueprint entando')}`);
         }
 
-        this.configOptions = jhContext.configOptions || {};
-        if (jhContext.databaseType === 'cassandra') {
+        this.configOptions = this.jhContext.configOptions || {};
+        if (this.jhContext.databaseType === 'cassandra') {
             this.pkType = 'UUID';
         }
+
     }
 
     get initializing() {
@@ -118,6 +123,12 @@ module.exports = class extends EntityServerGenerator {
         return generatedData;
     }
 
+    updateBundleDescriptor() {
+        this.entandoNeedleApi = new EntandoNeedle(this);
+        this.entandoNeedleApi.addWidgetToDescriptor(this.entityFileName);
+        this.entandoNeedleApi.addRolesToDescriptor(this.entityFileName);
+    }
+
     get writing() {
         // writing - Where you write the generator specific files (routes, controllers, etc)
         const jhipsterPhase = super._writing();
@@ -134,6 +145,7 @@ module.exports = class extends EntityServerGenerator {
             writeEntityServerFiles() {
                 this.writeFilesToDisk(serverFiles, this, false, null);
                 this.writeFilesToDisk(microFrontEndFiles, this, false, null);
+                this.updateBundleDescriptor();
             },
         };
         return { ...jhipsterPhase, ...myCustomSteps };
@@ -152,5 +164,13 @@ module.exports = class extends EntityServerGenerator {
     get end() {
         // end - Called last, cleanup, say good bye, etc
         return super._end();
+    }
+
+    log(msg) {
+        console.log(msg)
+    }
+
+    fs() {
+        return fs;
     }
 };

--- a/generators/entity-server/mfe-files.js
+++ b/generators/entity-server/mfe-files.js
@@ -13,7 +13,7 @@ const files = {
         },
         {
             file: '/detailsWidget/bundle/details-widget.ftl',
-            renameTo: generator => `/${generator.entityInstance}/detailsWidget/bundle/details-widget.ftl`,
+            renameTo: generator => `/${generator.entityInstance}/detailsWidget/bundle/${generator.entityFileName}-details-widget.ftl`,
             useBluePrint: true,
         },
         {
@@ -143,7 +143,7 @@ const files = {
         },
         {
             file: '/formWidget/bundle/form-widget.ftl',
-            renameTo: generator => `/${generator.entityInstance}/formWidget/bundle/form-widget.ftl`,
+            renameTo: generator => `/${generator.entityInstance}/formWidget/bundle/${generator.entityFileName}-form-widget.ftl`,
             useBluePrint: true,
         },
         {
@@ -294,7 +294,7 @@ const files = {
         },
         {
             file: '/tableWidget/bundle/table-widget.ftl',
-            renameTo: generator => `/${generator.entityInstance}/tableWidget/bundle/table-widget.ftl`,
+            renameTo: generator => `/${generator.entityInstance}/tableWidget/bundle/${generator.entityFileName}-table-widget.ftl`,
             useBluePrint: true,
         },
         {

--- a/generators/entity-server/mfe-files.js
+++ b/generators/entity-server/mfe-files.js
@@ -12,6 +12,16 @@ const files = {
             method: 'copy',
         },
         {
+            file: '/detailsWidget/bundle/details-widget.ftl',
+            renameTo: generator => `/${generator.entityInstance}/detailsWidget/bundle/details-widget.ftl`,
+            useBluePrint: true,
+        },
+        {
+            file: '/detailsWidget/bundle/details-widget-descriptor.yaml',
+            renameTo: generator => `/${generator.entityInstance}/detailsWidget/bundle/details-widget.yaml`,
+            useBluePrint: true,
+        },
+        {
             file: '/detailsWidget/package.json',
             renameTo: generator => `/${generator.entityInstance}/detailsWidget/package.json`,
             useBluePrint: true,
@@ -125,6 +135,16 @@ const files = {
             file: '/formWidget/jsconfig.json',
             renameTo: generator => `/${generator.entityInstance}/formWidget/jsconfig.json`,
             method: 'copy',
+        },
+        {
+            file: '/formWidget/bundle/form-widget-descriptor.yaml',
+            renameTo: generator => `/${generator.entityInstance}/formWidget/bundle/form-widget.yaml`,
+            useBluePrint: true,
+        },
+        {
+            file: '/formWidget/bundle/form-widget.ftl',
+            renameTo: generator => `/${generator.entityInstance}/formWidget/bundle/form-widget.ftl`,
+            useBluePrint: true,
         },
         {
             file: '/formWidget/package.json',
@@ -266,6 +286,16 @@ const files = {
             file: '/tableWidget/jsconfig.json',
             renameTo: generator => `/${generator.entityInstance}/tableWidget/jsconfig.json`,
             method: 'copy',
+        },
+        {
+            file: '/tableWidget/bundle/table-widget-descriptor.yaml',
+            renameTo: generator => `/${generator.entityInstance}/tableWidget/bundle/table-widget.yaml`,
+            useBluePrint: true,
+        },
+        {
+            file: '/tableWidget/bundle/table-widget.ftl',
+            renameTo: generator => `/${generator.entityInstance}/tableWidget/bundle/table-widget.ftl`,
+            useBluePrint: true,
         },
         {
             file: '/tableWidget/package.json',

--- a/generators/entity-server/needle-api/needle-server-bundle.js
+++ b/generators/entity-server/needle-api/needle-server-bundle.js
@@ -1,0 +1,30 @@
+const chalk = require('chalk');
+const needleServer = require('generator-jhipster/generators/server/needle-api/needle-server');
+
+const descriptorPath = 'bundle/descriptor.yaml';
+
+module.exports = class extends needleServer {
+
+    addWidgetToDescriptor(entityName) {
+
+        const errorMessage = `${chalk.yellow('Reference to widget in descriptor ')}
+            ${chalk.yellow(' not added.\n')}`;
+
+        let widgets = [`ui/widgets/${entityName}/tableWidget/table-widget.yaml`, `ui/widgets/${entityName}/detailsWidget/details-widget.yaml`,`ui/widgets/${entityName}/formWidget/form-widget.yaml`]
+        let i;
+
+        for(i=0; i<widgets.length; i++) {
+            const rewriteFileModel = this.generateFileModel(descriptorPath, 'entando-needle-descriptor-add-widgets', "    -"+widgets[i]);
+            this.addBlockContentToFile(rewriteFileModel, errorMessage);
+        }
+    }
+
+    addRolesToDescriptor(entityName) {
+
+        const errorMessage = `${chalk.yellow('Reference to widget in descriptor ')}
+            ${chalk.yellow(' not added.\n')}`;
+
+        const rewriteFileModelAdmin = this.generateFileModel(descriptorPath, 'entando-needle-descriptor-add-roles', `    - name: ${entityName}-admin\n      code: "${entityName}-admin"`);
+        this.addBlockContentToFile(rewriteFileModelAdmin, errorMessage);
+    }
+}

--- a/generators/entity-server/templates/ui/widgets/detailsWidget/bundle/details-widget-descriptor.yaml.ejs
+++ b/generators/entity-server/templates/ui/widgets/detailsWidget/bundle/details-widget-descriptor.yaml.ejs
@@ -1,0 +1,7 @@
+version: 0.0.1
+code: <%= entityFileName %>-details-widget
+titles:
+    en:  <%= entityClassHumanized %> Details Widget
+    it:  <%= entityClassHumanized %> Details Widget
+group: free
+customUiPath: <%= entityFileName %>-details-widget.ftl

--- a/generators/entity-server/templates/ui/widgets/detailsWidget/bundle/details-widget.ftl.ejs
+++ b/generators/entity-server/templates/ui/widgets/detailsWidget/bundle/details-widget.ftl.ejs
@@ -1,0 +1,3 @@
+<#-- Don't add anything above this line. The build scripts will automatically link the compiled JS and CSS for you and add them above this line so that the widget can be loaded-->
+
+<<%= entityFileName %>-details />

--- a/generators/entity-server/templates/ui/widgets/formWidget/bundle/form-widget-descriptor.yaml.ejs
+++ b/generators/entity-server/templates/ui/widgets/formWidget/bundle/form-widget-descriptor.yaml.ejs
@@ -1,0 +1,7 @@
+version: 0.0.1
+code: <%= entityFileName %>-form-widget
+titles:
+    en:  <%= entityClassHumanized %> Table Widget
+    it:  <%= entityClassHumanized %> Table Widget
+group: free
+customUiPath: <%= entityFileName %>-form-widget.ftl

--- a/generators/entity-server/templates/ui/widgets/formWidget/bundle/form-widget.ftl.ejs
+++ b/generators/entity-server/templates/ui/widgets/formWidget/bundle/form-widget.ftl.ejs
@@ -1,0 +1,4 @@
+<#-- Don't add anything above this line. The build scripts will automatically link the compiled JS and CSS for you and add them above this line so that the widget can be loaded-->
+
+<#-- This is the custom element -->
+<<%= entityFileName %>-form />

--- a/generators/entity-server/templates/ui/widgets/tableWidget/bundle/table-widget-descriptor.yaml.ejs
+++ b/generators/entity-server/templates/ui/widgets/tableWidget/bundle/table-widget-descriptor.yaml.ejs
@@ -1,0 +1,7 @@
+version: 0.0.1
+code: <%= entityFileName %>-table-widget
+titles:
+    en:  <%= entityClassHumanized %> Table Widget
+    it:  <%= entityClassHumanized %> Table Widget
+group: free
+customUiPath: <%= entityFileName %>-table-widget.ftl

--- a/generators/entity-server/templates/ui/widgets/tableWidget/bundle/table-widget.ftl.ejs
+++ b/generators/entity-server/templates/ui/widgets/tableWidget/bundle/table-widget.ftl.ejs
@@ -1,0 +1,4 @@
+<#-- Don't add anything above this line. The build scripts will automatically link the compiled JS and CSS for you and add them above this line so that the widget can be loaded-->
+
+<#-- This is the custom element -->
+<<%= entityFileName %>-table />

--- a/generators/server/files.js
+++ b/generators/server/files.js
@@ -3,6 +3,31 @@ const constants = require('generator-jhipster/generators/generator-constants');
 const { SERVER_MAIN_RES_DIR, SERVER_MAIN_SRC_DIR } = constants;
 
 const serverFiles = {
+
+    packageJson: [
+        {
+            templates: ['package.json']
+        },
+        {
+            templates: ['buildWidgets.sh']
+        },
+        {
+            templates: ['installWidgets.sh']
+        },
+        {
+            templates: ['buildBundle.sh']
+        },
+        {
+            PATH: '.',
+            templates: [
+                {
+                    useBluePrint: true,
+                    file: 'bundle/descriptor.yaml',
+                    renameTo: generator => `./bundle/descriptor.yaml`,
+                }
+            ]
+        }
+    ],
     server: [
         {
             path: SERVER_MAIN_RES_DIR,
@@ -51,7 +76,7 @@ const serverFiles = {
                     file: 'package/web/rest/schema/AppConfigSchemaResource.java',
                     renameTo: generator =>
                         `${generator.packageFolder}/web/rest/schema/${titleCaseBaseName(generator)}ConfigSchemaResource.java`
-                }
+                },
             ]
         }
     ]

--- a/generators/server/templates/buildBundle.sh.ejs
+++ b/generators/server/templates/buildBundle.sh.ejs
@@ -1,8 +1,10 @@
 #!/bin/bash
 
 # This command assumes that the widgets are all under ui/widgets/<entity>/<widget>. The command finds all of the micro-frontends in those folders and
-# copies the result of the build into the bundle resources folder so that the bundle can be deployed to a digital exchange instance (or imported on an existing page)
-find ui/widgets -maxdepth 2 -mindepth 2 -type d -not -path "*utils*" -exec bash -c "mkdir -p bundle/'{}'/resources/static/{js,css} && cp '{}'/build/static/js/*.js bundle/'{}'/resources/static/js && cp '{}'/build/static/css/*.css bundle/'{}'/resources/static/css && mkdir -p bundle/{} && cp '{}'/bundle/* bundle/{}/" \;
+# copies the result of the build into the bundle resources folder so that the bundle can be deployed to a digital exchange instance (or imported on an existing page).
+# The command also copies css optionally with this structure since some widgets will be js only 2>/dev/null || :
+
+find ui/widgets -maxdepth 2 -mindepth 2 -type d -not -path "*utils*" -exec bash -c "mkdir -p bundle/'{}'/resources/static/{js,css} && cp '{}'/build/static/js/*.js bundle/'{}'/resources/static/js && cp '{}'/build/static/css/*.css bundle/'{}'/resources/static/css 2>/dev/null || : && mkdir -p bundle/{} && cp '{}'/bundle/* bundle/{}/" \;
 
 #Fetch the top level service name from the pom and use this as the context directory for the publishing of assets specific to the project when building the bundle
 artifactId=`cat pom.xml | grep "^    <artifactId>.*</artifactId>$" | awk -F'[><]' '{print $3}'`

--- a/generators/server/templates/buildBundle.sh.ejs
+++ b/generators/server/templates/buildBundle.sh.ejs
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+#This command assumes that the widgets are all under ui/widgets/<entity>/<widget>. The command finds all of the micro-frontends in those folders and copies the result of the build into the bundle resources folder so that the bundle can be deployed to a digital exchange instance (or imported on an existing page)
+
+find ui/widgets -maxdepth 2 -mindepth 2 -type d -not -path "*utils*" -exec bash -c "mkdir -p bundle/'{}'/resources/{js,css} && cp '{}'/build/static/js/*.js bundle/'{}'/resources/js && cp '{}'/build/static/css/*.css bundle/'{}'/resources/css && cp '{}'/bundle/* bundle/{}/" \;
+
+#Fetch the top level service name from the pom and use this as the context directory for the publishing of assets specific to the project when building the bundle
+artifactId=`cat pom.xml | grep "^    <artifactId>.*</artifactId>$" | awk -F'[><]' '{print $3}'`
+
+echo "Generating bundle for service ${artifactId}"
+
+#For each widget under the structure ui/widgets/<entity>/<widget> generate an FTL file that imports the css and js that goes with that widget
+for dir in `find bundle/ui/widgets -maxdepth 2 -mindepth 2 -type d -not -path "*utils*" -exec bash -c "cd {} && pwd" \;`;
+do
+    for ftlFile in `ls $dir/*.ftl`;
+    do
+        echo "Adding js and css build files to ${ftlFile}"
+        for jsfile in `ls $dir/resources/js`;
+        do
+            widgetName=`basename $dir`
+            echo "Adding script to js for widget ${widgetName} for file ${jsfile}"
+            echo "<script src=\"<@wp.resourceURL />${artifactId}/static/js/${jsfile}\"></script>"$'\n'"$(cat $ftlFile)" > $ftlFile
+        done
+
+        for cssfile in `ls $dir/resources/css`;
+        do
+          echo "Adding link to css file for widget for file ${cssfile}"
+          echo "<link href=\"<@wp.resourceURL />${artifactId}/static/css/${cssfile}\" rel=\"stylesheet\">"$'\n'"$(cat $ftlFile)" > $ftlFile
+        done
+    done
+done

--- a/generators/server/templates/buildBundle.sh.ejs
+++ b/generators/server/templates/buildBundle.sh.ejs
@@ -1,31 +1,43 @@
 #!/bin/bash
 
-#This command assumes that the widgets are all under ui/widgets/<entity>/<widget>. The command finds all of the micro-frontends in those folders and copies the result of the build into the bundle resources folder so that the bundle can be deployed to a digital exchange instance (or imported on an existing page)
-
-find ui/widgets -maxdepth 2 -mindepth 2 -type d -not -path "*utils*" -exec bash -c "mkdir -p bundle/'{}'/resources/{js,css} && cp '{}'/build/static/js/*.js bundle/'{}'/resources/js && cp '{}'/build/static/css/*.css bundle/'{}'/resources/css && cp '{}'/bundle/* bundle/{}/" \;
+# This command assumes that the widgets are all under ui/widgets/<entity>/<widget>. The command finds all of the micro-frontends in those folders and
+# copies the result of the build into the bundle resources folder so that the bundle can be deployed to a digital exchange instance (or imported on an existing page)
+find ui/widgets -maxdepth 2 -mindepth 2 -type d -not -path "*utils*" -exec bash -c "mkdir -p bundle/'{}'/resources/static/{js,css} && cp '{}'/build/static/js/*.js bundle/'{}'/resources/static/js && cp '{}'/build/static/css/*.css bundle/'{}'/resources/static/css && mkdir -p bundle/{} && cp '{}'/bundle/* bundle/{}/" \;
 
 #Fetch the top level service name from the pom and use this as the context directory for the publishing of assets specific to the project when building the bundle
 artifactId=`cat pom.xml | grep "^    <artifactId>.*</artifactId>$" | awk -F'[><]' '{print $3}'`
 
 echo "Generating bundle for service ${artifactId}"
 
-#For each widget under the structure ui/widgets/<entity>/<widget> generate an FTL file that imports the css and js that goes with that widget
+mkdir -p bundle/resources/static/{js,css}
+
+# For each widget under the structure ui/widgets/<entity>/<widget> generate an FTL file that imports the css and js that goes with that widget.
+# The FTL file from the widget itself is preserved and the imports are added at the top of the widget
 for dir in `find bundle/ui/widgets -maxdepth 2 -mindepth 2 -type d -not -path "*utils*" -exec bash -c "cd {} && pwd" \;`;
 do
-    for ftlFile in `ls $dir/*.ftl`;
+    widgetName=`basename $dir`
+    echo "Generating bundle ${widgetName} for $dir"
+    for ftlName in `ls $dir/*.ftl`
     do
-        echo "Adding js and css build files to ${ftlFile}"
-        for jsfile in `ls $dir/resources/js`;
+        #For every JS file add a script reference in the widget FTL
+        for jsfile in `ls $dir/resources/static/js`;
         do
-            widgetName=`basename $dir`
+            # This moves the referenced file to the top level bundle/resources/static dir for correct processing when loaded
+            cp $dir/resources/static/js/$jsfile bundle/resources/static/js/
             echo "Adding script to js for widget ${widgetName} for file ${jsfile}"
-            echo "<script src=\"<@wp.resourceURL />${artifactId}/static/js/${jsfile}\"></script>"$'\n'"$(cat $ftlFile)" > $ftlFile
+            echo "<script src=\"<@wp.resourceURL />${artifactId}/static/js/${jsfile}\"></script>"$'\n'"$(cat $ftlName)" > $ftlName
         done
 
-        for cssfile in `ls $dir/resources/css`;
+        # For every CSS file add a script reference in the widget FTL
+        for cssfile in `ls $dir/resources/static/css`;
         do
+          # This moves the referenced file to the top level bundle/resources/static dir for correct processing when loaded
+          cp $dir/resources/static/css/$cssfile bundle/resources/static/css/
           echo "Adding link to css file for widget for file ${cssfile}"
-          echo "<link href=\"<@wp.resourceURL />${artifactId}/static/css/${cssfile}\" rel=\"stylesheet\">"$'\n'"$(cat $ftlFile)" > $ftlFile
+          echo "<link href=\"<@wp.resourceURL />${artifactId}/static/css/${cssfile}\" rel=\"stylesheet\">"$'\n'"$(cat $ftlName)" > $ftlName
         done
     done
+
+    #Cleanup the resources that were copied into the widget folders specifically. They are now copied into the main bundle folder
+    rm -rf $dir/resources
 done

--- a/generators/server/templates/buildWidgets.sh.ejs
+++ b/generators/server/templates/buildWidgets.sh.ejs
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+find ui/widgets/ -maxdepth 2 -mindepth 2 -type d -not -path "*utils*" -exec bash -c "cd '{}' && npm run build" \;

--- a/generators/server/templates/bundle/descriptor.yaml.ejs
+++ b/generators/server/templates/bundle/descriptor.yaml.ejs
@@ -1,0 +1,25 @@
+version: entando.org/v1alpha1
+code: <%=baseName%>_bundle
+description: This is the <%=baseName%> bundle
+
+components:
+  service:
+    image: FIXME
+    ingressPath: /<%=baseName%>
+    healthCheckPath: /actuator/health
+    dbms: <%=prodDatabaseType%>
+    roles:
+    - name: <%=baseName%>-admin
+      code: "<%=baseName%>-admin"
+/* entando-needle-descriptor-add-roles - Entando blueprint will add roles here */
+
+    permissions: []
+
+  widgets:
+/* entando-needle-descriptor-add-widgets - Entando blueprint will add widget bundle files here */
+
+  pageModels:
+
+  contentTypes:
+
+  contentModels:

--- a/generators/server/templates/bundle/descriptor.yaml.ejs
+++ b/generators/server/templates/bundle/descriptor.yaml.ejs
@@ -11,12 +11,12 @@ components:
     roles:
     - name: <%=baseName%>-admin
       code: "<%=baseName%>-admin"
-/* entando-needle-descriptor-add-roles - Entando blueprint will add roles here */
+# entando-needle-descriptor-add-roles - Entando blueprint will add roles here
 
     permissions: []
 
   widgets:
-/* entando-needle-descriptor-add-widgets - Entando blueprint will add widget bundle files here */
+# entando-needle-descriptor-add-widgets - Entando blueprint will add widget bundle files here
 
   pageModels:
 

--- a/generators/server/templates/installWidgets.sh.ejs
+++ b/generators/server/templates/installWidgets.sh.ejs
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+find ui/widgets/ -maxdepth 2 -mindepth 2 -type d -not -path "*utils*" -exec bash -c "cd '{}' && npm install" \;

--- a/generators/server/templates/package.json.ejs
+++ b/generators/server/templates/package.json.ejs
@@ -1,0 +1,44 @@
+<%#
+ Copyright 2013-2019 the original author or authors from the JHipster project.
+
+ This file is part of the JHipster project, see https://www.jhipster.tech/
+ for more information.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-%>
+{
+  "name": "<%= dasherizedBaseName %>",
+  "version": "0.0.0",
+  "description": "Description for <%= baseName %>",
+  "private": true,
+  "license": "UNLICENSED",
+  "cacheDirectories": [
+    "node_modules"
+  ],
+  "devDependencies": {
+    <%_ otherModules.forEach(module => { _%>
+    "<%= module.name %>": "<%= module.version %>",
+    <%_ }); _%>
+    "generator-jhipster": "<%= jhipsterVersion %>",
+    "@openapitools/openapi-generator-cli": "0.0.14-4.0.2"
+  },
+  "engines": {
+    "node": ">=8.9.0"
+  },
+  "scripts": {
+    "install-build-bundle": "npm run install-widgets && npm run build-widgets && npm run bundle-widgets",
+    "install-widgets": "chmod a+x installWidgets.sh && ./installWidgets.sh",
+    "build-widgets": "chmod a+x buildWidgets.sh && ./buildWidgets.sh",
+    "bundle-widgets": "chmod a+x buildBundle.sh && ./buildBundle.sh"
+  }
+}


### PR DESCRIPTION
This adds the following for generation:

- widget ftl file baselin
- descriptor.yaml for the full bundle. Without the image name. will need to be manually set
- Adds widgets to the descriptor using a needle
- Adds default roles to the descriptor using a needle

At build time to try the full bundle generation out:
- Run blueprint
- Add an entity (or entities)
- Run `npm run install-build-bundle`
- Adds the imports for the css and js to the FTL file.

The command above will run `npm install` on all of the widgets, run `npm build` on all of the widgets and run the `buildBundle.sh` script which copies all of the generated yaml and ftl files into the top level bundle folder. It also will create the resources folder for each of the widgets and add links to the resources to the FTL file so that the widget can be installed in the Entando App instance. 

Creating the PR for initial review. Still need to try installing the bundle. I expect that the resources folder in its current location 

