### PR TITLE
Fix imports js and css files on new lines into template

### DIFF
--- a/generators/server/templates/prepareBundle.sh
+++ b/generators/server/templates/prepareBundle.sh
@@ -30,7 +30,8 @@ function injectResource() {
     local destFile="$2"
 
     echo "- Injecting resource $resource in $destFile"
-    sed -i 's|'"$INJECTION_POINT"'|'"$resource"'\n'"$INJECTION_POINT"'|g' "$destFile"
+    sed -i '.bak' 's|'"$INJECTION_POINT"'|'"$resource"'\
+'"$INJECTION_POINT"'|g' "$destFile"
 }
 
 function updateFTLTemplate() {


### PR DESCRIPTION
Fixed the import of js and css files on new lines during populate-bundle. It works on a macOS. 
@joewhite101 gives me the fixed stateline `sed -i '.bak' 's|'"$INJECTION_POINT"'|'"$resource"'\n'"$INJECTION_POINT"'|g' "$destFile` but the “\n” for the new line doesn’t work with sed.