### PR TITLE
ENG-448 re-rendering causes creating multiple event listeners

### DIFF
--- a/generators/entity-server/templates/ui/widgets/formWidget/src/custom-elements/EntityFormElement.js.ejs
+++ b/generators/entity-server/templates/ui/widgets/formWidget/src/custom-elements/EntityFormElement.js.ejs
@@ -77,6 +77,9 @@ class <%= entityClass %>FormElement extends HTMLElement {
     if (!Object.values(ATTRIBUTES).includes(name)) {
       throw new Error(`Untracked changed attribute: ${name}`);
     }
+    if (name === ATTRIBUTES.disableDefaultEventHandler) {
+      this.onToggleDisableDefaultEvent();
+    }
     this.render();
   }
 
@@ -110,6 +113,8 @@ class <%= entityClass %>FormElement extends HTMLElement {
       this.keycloak = { ...getKeycloakInstance(), initialized: true };
       this.render();
     });
+
+    this.onToggleDisableDefaultEvent();
 
     this.render();
 
@@ -168,19 +173,9 @@ class <%= entityClass %>FormElement extends HTMLElement {
     };
   }
 
-  render() {
-    const serviceUrl = this.getAttribute(ATTRIBUTES.serviceUrl) || '';
-
-    const hidden = this.getAttribute(ATTRIBUTES.hidden) === 'true';
-    if (hidden) {
-      ReactDOM.render(<></>);
-      return;
-    }
-
-    const locale = this.getAttribute(ATTRIBUTES.locale);
-    setLocale(locale);
-
+  onToggleDisableDefaultEvent() {
     const disableEventHandler = this.getAttribute(ATTRIBUTES.disableDefaultEventHandler) === 'true';
+
     if (disableEventHandler !== this.defaultEventHandlerDisabled) {
       if (!disableEventHandler) {
         const defaultWidgetEventHandler = this.defaultWidgetEventHandler();
@@ -199,6 +194,19 @@ class <%= entityClass %>FormElement extends HTMLElement {
       }
       this.defaultEventHandlerDisabled = disableEventHandler;
     }
+  }
+
+  render() {
+    const serviceUrl = this.getAttribute(ATTRIBUTES.serviceUrl) || '';
+
+    const hidden = this.getAttribute(ATTRIBUTES.hidden) === 'true';
+    if (hidden) {
+      ReactDOM.render(<></>);
+      return;
+    }
+
+    const locale = this.getAttribute(ATTRIBUTES.locale);
+    setLocale(locale);
 
     const id = this.getAttribute(ATTRIBUTES.id);
 

--- a/generators/entity-server/templates/ui/widgets/formWidget/src/custom-elements/EntityFormElement.js.ejs
+++ b/generators/entity-server/templates/ui/widgets/formWidget/src/custom-elements/EntityFormElement.js.ejs
@@ -50,6 +50,8 @@ class <%= entityClass %>FormElement extends HTMLElement {
 
   unsubscribeFromKeycloakEvent;
 
+  defaultEventHandlerDisabled;
+
   onCreate = createWidgetEventPublisher(OUTPUT_EVENT_TYPES.create);
 
   onCancelEditing = createWidgetEventPublisher(OUTPUT_EVENT_TYPES.cancelEditing);
@@ -179,20 +181,23 @@ class <%= entityClass %>FormElement extends HTMLElement {
     setLocale(locale);
 
     const disableEventHandler = this.getAttribute(ATTRIBUTES.disableDefaultEventHandler) === 'true';
-    if (!disableEventHandler) {
-      const defaultWidgetEventHandler = this.defaultWidgetEventHandler();
+    if (disableEventHandler !== this.defaultEventHandlerDisabled) {
+      if (!disableEventHandler) {
+        const defaultWidgetEventHandler = this.defaultWidgetEventHandler();
 
-      this.unsubscribeFromWidgetEvents = subscribeToWidgetEvents(
-        Object.values(INPUT_EVENT_TYPES),
-        defaultWidgetEventHandler
-      );
-    } else {
-      if (this.unsubscribeFromWidgetEvents) {
-        this.unsubscribeFromWidgetEvents();
+        this.unsubscribeFromWidgetEvents = subscribeToWidgetEvents(
+          Object.values(INPUT_EVENT_TYPES),
+          defaultWidgetEventHandler
+        );
+      } else {
+        if (this.unsubscribeFromWidgetEvents) {
+          this.unsubscribeFromWidgetEvents();
+        }
+        if (this.unsubscribeFromKeycloakEvent) {
+          this.unsubscribeFromKeycloakEvent();
+        }
       }
-      if (this.unsubscribeFromKeycloakEvent) {
-        this.unsubscribeFromKeycloakEvent();
-      }
+      this.defaultEventHandlerDisabled = disableEventHandler;
     }
 
     const id = this.getAttribute(ATTRIBUTES.id);

--- a/generators/entity-server/templates/ui/widgets/tableWidget/src/custom-elements/EntityTableElement.js.ejs
+++ b/generators/entity-server/templates/ui/widgets/tableWidget/src/custom-elements/EntityTableElement.js.ejs
@@ -51,6 +51,8 @@ class <%= ComponentName %> extends HTMLElement {
 
   unsubscribeFromKeycloakEvent;
 
+  defaultEventHandlerDisabled;
+
   keycloak = getKeycloakInstance();
 
   onAdd = createWidgetEventPublisher(OUTPUT_EVENT_TYPES.add);
@@ -140,20 +142,24 @@ class <%= ComponentName %> extends HTMLElement {
     const serviceUrl = this.getAttribute(ATTRIBUTES.serviceUrl) || '';
 
     const disableEventHandler = this.getAttribute(ATTRIBUTES.disableDefaultEventHandler) === 'true';
-    if (!disableEventHandler) {
-      const defaultWidgetEventHandler = this.defaultWidgetEventHandler();
 
-      this.unsubscribeFromWidgetEvents = subscribeToWidgetEvents(
-        Object.values(INPUT_EVENT_TYPES),
-        defaultWidgetEventHandler
-      );
-    } else {
-      if (this.unsubscribeFromWidgetEvents) {
-        this.unsubscribeFromWidgetEvents();
+    if (disableEventHandler !== this.defaultEventHandlerDisabled) {
+      if (!disableEventHandler) {
+        const defaultWidgetEventHandler = this.defaultWidgetEventHandler();
+
+        this.unsubscribeFromWidgetEvents = subscribeToWidgetEvents(
+          Object.values(INPUT_EVENT_TYPES),
+          defaultWidgetEventHandler
+        );
+      } else {
+        if (this.unsubscribeFromWidgetEvents) {
+          this.unsubscribeFromWidgetEvents();
+        }
+        if (this.unsubscribeFromKeycloakEvent) {
+          this.unsubscribeFromKeycloakEvent();
+        }
       }
-      if (this.unsubscribeFromKeycloakEvent) {
-        this.unsubscribeFromKeycloakEvent();
-      }
+      this.defaultEventHandlerDisabled = disableEventHandler;
     }
 
     ReactDOM.render(

--- a/generators/entity-server/templates/ui/widgets/tableWidget/src/custom-elements/EntityTableElement.js.ejs
+++ b/generators/entity-server/templates/ui/widgets/tableWidget/src/custom-elements/EntityTableElement.js.ejs
@@ -76,6 +76,11 @@ class <%= ComponentName %> extends HTMLElement {
     if (!Object.values(ATTRIBUTES).includes(name)) {
       throw new Error(`Untracked changed attribute: ${name}`);
     }
+
+    if (name === ATTRIBUTES.disableDefaultEventHandler) {
+      this.onToggleDisableDefaultEvent();
+    }
+    
     this.render();
   }
 
@@ -107,6 +112,8 @@ class <%= ComponentName %> extends HTMLElement {
       this.render();
     });
 
+    this.onToggleDisableDefaultEvent();
+
     this.render();
 
     retargetEvents(shadowRoot);
@@ -128,19 +135,7 @@ class <%= ComponentName %> extends HTMLElement {
     };
   }
 
-  render() {
-    const hidden = this.getAttribute(ATTRIBUTES.hidden) === 'true';
-    if (hidden) {
-      return;
-    }
-
-    const locale = this.getAttribute(ATTRIBUTES.locale);
-    setLocale(locale);
-
-    const paginationMode = this.getAttribute(ATTRIBUTES.paginationMode) || '';
-
-    const serviceUrl = this.getAttribute(ATTRIBUTES.serviceUrl) || '';
-
+  onToggleDisableDefaultEvent() {
     const disableEventHandler = this.getAttribute(ATTRIBUTES.disableDefaultEventHandler) === 'true';
 
     if (disableEventHandler !== this.defaultEventHandlerDisabled) {
@@ -161,6 +156,20 @@ class <%= ComponentName %> extends HTMLElement {
       }
       this.defaultEventHandlerDisabled = disableEventHandler;
     }
+  }
+
+  render() {
+    const hidden = this.getAttribute(ATTRIBUTES.hidden) === 'true';
+    if (hidden) {
+      return;
+    }
+
+    const locale = this.getAttribute(ATTRIBUTES.locale);
+    setLocale(locale);
+
+    const paginationMode = this.getAttribute(ATTRIBUTES.paginationMode) || '';
+
+    const serviceUrl = this.getAttribute(ATTRIBUTES.serviceUrl) || '';
 
     ReactDOM.render(
       <KeycloakContext.Provider value={this.keycloak}>


### PR DESCRIPTION
creating event listeners is in render method and much of the time the web component rerenders. solution is to add a event-disable property to avoid repetitive event listener creation